### PR TITLE
Update installer.py

### DIFF
--- a/installer.py
+++ b/installer.py
@@ -78,8 +78,8 @@ def install_qemu() -> None:
 
             def verify():
                 request.urlretrieve(checksum_url, checksum_file)
-                with open(installer_file, "rb", encoding="utf-8") as inst, open(
-                    checksum_file, "r", encoding="utf-8"
+                with open(installer_file, "rb") as inst, open(
+                    checksum_file, "r"
                 ) as chksm:
                     bytes_read = inst.read()
                     hash_read = hashlib.sha512(bytes_read).hexdigest()


### PR DESCRIPTION
fixes binary issue when installing qemu
![image](https://github.com/Kippiii/jabberwocky-container-manager/assets/34556872/7cee8ba4-7f21-4bec-a188-6550fa11a846)
